### PR TITLE
feat(security): mask API key input as password field

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
             <div class="config-form">
                 <div class="form-group">
                     <label for="apiKey" data-i18n="apiKeyLabel">API Key</label>
-                    <input type="text" id="apiKey" data-i18n-placeholder="apiKeyPlaceholder" placeholder="输入你的 Testmail API Key">
+                    <input type="password" id="apiKey" data-i18n-placeholder="apiKeyPlaceholder" placeholder="输入你的 Testmail API Key">
                 </div>
                 <div class="form-group">
                     <label for="namespace" data-i18n="namespaceLabel">Namespace</label>


### PR DESCRIPTION
## Summary
- 将 API Key 输入框类型从 `text` 改为 `password`，输入时显示为圆点，防止旁观者看到敏感信息

## Test Plan
- [x] 在浏览器中打开页面，确认 API Key 输入框显示为密码形式
- [x] 输入 API Key 后确认显示为圆点遮罩
- [x] 确认功能正常，可以正常获取邮件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API Key input field now hides entered values for improved security

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->