### PR TITLE
fix: enable scrolling in email content area

### DIFF
--- a/style.css
+++ b/style.css
@@ -565,7 +565,8 @@ body {
     background: var(--md-sys-color-card-bg);
     border-radius: 8px;
     border: 1px solid var(--md-sys-color-card-border);
-    overflow: hidden;
+    overflow: auto;
+    max-height: 600px;
 }
 
 iframe {
@@ -585,7 +586,7 @@ iframe {
     color: var(--md-sys-color-text-secondary);
     white-space: pre-wrap;
     word-break: break-word;
-    max-height: 400px;
+    max-height: 600px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary

- 修改 `.iframe-wrapper` 的 `overflow: hidden` 为 `overflow: auto`，允许 HTML 视图滚动
- 为 `.iframe-wrapper` 添加 `max-height: 600px` 限制最大高度
- 将 `.text-content` 的 `max-height` 从 400px 增加到 600px，与 HTML 视图保持一致

Closes #1

## 自测结果

**环境：** Chrome 浏览器，本地开发服务器

**测试步骤：**
1. 启动本地服务器查看页面
2. 加载包含长内容的邮件
3. 验证 HTML 视图可以滚动查看完整内容
4. 切换到 TEXT 视图，验证文本内容可以滚动
5. 测试鼠标滚轮、拖动滚动条滚动方式

**结果：** HTML 和 TEXT 视图均可正常滚动，滚动条可见且功能正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrolling functionality throughout the application. Content areas now display expanded height limits, enabling users to view more information before scrolling becomes necessary.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->