### PR TITLE
feat(ui): replace theme toggle with dropdown selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,17 @@
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
+    <script>
+        try {
+            var c = JSON.parse(localStorage.getItem('testmail-webviewer-config'));
+            if (c && c.theme === 'violet') {
+                document.documentElement.setAttribute('data-theme', 'violet');
+                document.querySelectorAll('meta[name="theme-color"]').forEach(function(m) {
+                    if (m.media && m.media.indexOf('light') > -1) m.content = '#7C3AED';
+                });
+            }
+        } catch(e) {}
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Testmail WebViewer</title>
     <meta name="description" content="A Material Design web application for visualizing emails from Testmail.app. Modern, responsive interface for developers and testers.">
@@ -91,6 +102,28 @@
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                 </a>
+                <div class="theme-selector" id="themeSelector">
+                    <button id="themeBtn" class="chip btn-chip" style="cursor: pointer; border: none; color: inherit;" title="Switch Theme">
+                        <svg viewBox="0 0 24 24" class="icon-theme" style="width: 18px; height: 18px; fill: currentColor;">
+                            <path d="M12 22C6.49 22 2 17.51 2 12S6.49 2 12 2s10 4.04 10 9c0 3.31-2.69 6-6 6h-1.77c-.28 0-.5.22-.5.5 0 .12.05.23.13.33.41.47.64 1.06.64 1.67A2.5 2.5 0 0 1 12 22zm0-18c-4.41 0-8 3.59-8 8s3.59 8 8 8c.28 0 .5-.22.5-.5a.54.54 0 0 0-.14-.35c-.41-.46-.63-1.05-.63-1.65a2.5 2.5 0 0 1 2.5-2.5H16c2.21 0 4-1.79 4-4 0-3.86-3.59-7-8-7zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 10 6.5 10s1.5.67 1.5 1.5S7.33 13 6.5 13zm3-4C8.67 9 8 8.33 8 7.5S8.67 6 9.5 6s1.5.67 1.5 1.5S10.33 9 9.5 9zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 6 14.5 6s1.5.67 1.5 1.5S15.33 9 14.5 9zm3 4c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+                        </svg>
+                        <svg viewBox="0 0 24 24" style="width: 14px; height: 14px; fill: currentColor;">
+                            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+                        </svg>
+                    </button>
+                    <div class="theme-dropdown" id="themeDropdown">
+                        <button class="theme-option" data-theme="indigo">
+                            <span class="theme-swatch" style="background: #6366F1"></span>
+                            Indigo
+                            <svg class="theme-check" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
+                        </button>
+                        <button class="theme-option" data-theme="violet">
+                            <span class="theme-swatch" style="background: #7C3AED"></span>
+                            Violet
+                            <svg class="theme-check" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
+                        </button>
+                    </div>
+                </div>
                 <button id="langBtn" class="chip btn-chip" style="cursor: pointer; border: none; color: inherit;">
                     EN
                 </button>
@@ -131,10 +164,14 @@
         <main class="email-list-container">
             <div id="emailList" class="email-list">
                 <div class="empty-state">
-                    <svg viewBox="0 0 24 24" class="empty-icon">
-                        <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
-                    </svg>
+                    <div class="empty-state-illustration">
+                        <div class="empty-envelope"></div>
+                        <div class="empty-star"></div>
+                        <div class="empty-star"></div>
+                        <div class="empty-star"></div>
+                    </div>
                     <p data-i18n="emptyState">请先配置 API 并获取邮件</p>
+                    <span class="empty-hint" data-i18n="emptyHint">在上方填写 API Key 和 Namespace 后点击获取</span>
                 </div>
             </div>
         </main>

--- a/style.css
+++ b/style.css
@@ -28,6 +28,16 @@
     --elevation-3: 0px 10px 20px rgba(0, 0, 0, 0.12);
     --transition-normal: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-smooth: 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    --theme-appbar-shadow: rgba(99,102,241,0.25);
+    --theme-focus-ring: rgba(99,102,241,0.1);
+    --theme-btn-glow: rgba(99,102,241,0.35);
+    --theme-hover-bg: rgba(99,102,241,0.08);
+    --theme-avatar-shadow: none;
+    --theme-spinner-top: #818CF8;
+    --theme-spinner-right: #A78BFA;
+    --theme-tab-active-bg: var(--md-sys-color-surface);
+    --theme-tab-active-color: var(--md-sys-color-primary);
+    --theme-tab-active-shadow: var(--elevation-1);
 }
 
 /* Dark Mode */
@@ -69,6 +79,8 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    scrollbar-width: thin;
+    scrollbar-color: var(--md-sys-color-outline-variant) transparent;
 }
 
 body {
@@ -117,9 +129,9 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    box-shadow: 0 4px 20px rgba(99,102,241,0.25);
+    box-shadow: 0 4px 20px var(--theme-appbar-shadow);
     position: relative;
-    overflow: hidden;
+    z-index: 1;
     animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
 }
 
@@ -191,6 +203,82 @@ body {
     align-items: center;
     gap: 6px;
     border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: all var(--transition-normal);
+}
+
+.chip:hover {
+    background: rgba(255, 255, 255, 0.22);
+}
+
+/* Theme Selector Dropdown */
+.theme-selector {
+    position: relative;
+}
+
+.theme-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    min-width: 140px;
+    background: rgba(15, 23, 42, 0.9);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 12px;
+    padding: 4px;
+    box-shadow: var(--elevation-3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity var(--transition-normal), transform var(--transition-normal);
+    z-index: 100;
+}
+
+.theme-dropdown.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.theme-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.85);
+    font-family: var(--font-family);
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color var(--transition-normal);
+}
+
+.theme-option:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.theme-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.theme-check {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+    margin-left: auto;
+    opacity: 0;
+    transition: opacity var(--transition-normal);
+}
+
+.theme-option.active .theme-check {
+    opacity: 1;
 }
 
 /* Icons */
@@ -259,6 +347,11 @@ body {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    transition: color var(--transition-normal);
+}
+
+.form-group:focus-within label {
+    color: var(--md-sys-color-primary);
 }
 
 .form-group input {
@@ -280,7 +373,7 @@ body {
 .form-group input:focus {
     outline: none;
     border-color: var(--md-sys-color-primary);
-    box-shadow: 0 0 0 3px rgba(99,102,241,0.1), var(--elevation-glow);
+    box-shadow: 0 0 0 3px var(--theme-focus-ring), var(--elevation-glow);
 }
 
 .form-group input::placeholder {
@@ -319,7 +412,7 @@ body {
 
 .btn-primary:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgba(99,102,241,0.35);
+    box-shadow: 0 4px 15px var(--theme-btn-glow);
 }
 
 .btn-primary:hover::after {
@@ -348,16 +441,90 @@ body {
     color: var(--md-sys-color-outline);
 }
 
+.empty-state-illustration {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    margin-bottom: 24px;
+}
+
+.empty-envelope {
+    width: 80px;
+    height: 56px;
+    background: var(--gradient-primary);
+    border-radius: 8px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0.15;
+    animation: floatEnvelope 3s ease-in-out infinite;
+}
+
+.empty-envelope::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50%;
+    background: inherit;
+    clip-path: polygon(0 0, 50% 100%, 100% 0);
+    border-radius: 8px 8px 0 0;
+    opacity: 0.6;
+}
+
+.empty-star {
+    width: 8px;
+    height: 8px;
+    background: var(--md-sys-color-primary);
+    border-radius: 50%;
+    position: absolute;
+    opacity: 0.3;
+}
+
+.empty-star:nth-child(2) {
+    top: 10px;
+    right: 20px;
+    animation: twinkle 2s ease-in-out infinite;
+}
+
+.empty-star:nth-child(3) {
+    bottom: 15px;
+    left: 15px;
+    width: 6px;
+    height: 6px;
+    animation: twinkle 2s ease-in-out 0.5s infinite;
+}
+
+.empty-star:nth-child(4) {
+    top: 25px;
+    left: 25px;
+    width: 5px;
+    height: 5px;
+    animation: twinkle 2s ease-in-out 1s infinite;
+}
+
 .empty-icon {
     width: 72px;
     height: 72px;
-    fill: var(--md-sys-color-outline-variant);
-    margin-bottom: 16px;
-    opacity: 0.5;
+    fill: var(--md-sys-color-primary);
+    margin-bottom: 20px;
+    opacity: 0.2;
+    animation: floatEnvelope 3s ease-in-out infinite;
 }
 
 .empty-state p {
-    font-size: 15px;
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--md-sys-color-text-tertiary);
+}
+
+.empty-state .empty-hint {
+    font-size: 13px;
+    color: var(--md-sys-color-outline);
+    margin-top: 8px;
+    font-weight: 400;
 }
 
 /* Email Item */
@@ -382,14 +549,17 @@ body {
     gap: 14px;
     align-items: center;
     user-select: none;
+    transition: background-color var(--transition-normal), transform var(--transition-normal);
 }
 
 .email-summary:hover {
     background: var(--gradient-subtle);
+    transform: translateY(-1px);
 }
 
 .email-summary:active {
-    background-color: rgba(99,102,241,0.08);
+    background-color: var(--theme-hover-bg);
+    transform: translateY(0);
 }
 
 .avatar {
@@ -405,6 +575,7 @@ body {
     font-size: 15px;
     flex-shrink: 0;
     transition: transform var(--transition-normal);
+    box-shadow: var(--theme-avatar-shadow);
 }
 
 .email-summary:hover .avatar {
@@ -574,7 +745,11 @@ body {
 }
 
 .btn-text:hover {
-    background-color: rgba(99,102,241,0.08);
+    background-color: var(--theme-hover-bg);
+}
+
+.btn-text:active {
+    transform: scale(0.97);
 }
 
 .tabs {
@@ -606,9 +781,9 @@ body {
 }
 
 .tab-btn.active {
-    background: var(--md-sys-color-surface);
-    color: var(--md-sys-color-primary);
-    box-shadow: var(--elevation-1);
+    background: var(--theme-tab-active-bg);
+    color: var(--theme-tab-active-color);
+    box-shadow: var(--theme-tab-active-shadow);
 }
 
 .iframe-wrapper {
@@ -677,6 +852,7 @@ iframe {
 .attachment-item:hover {
     border-color: var(--md-sys-color-primary);
     background: var(--md-sys-color-primary-container);
+    transform: translateY(-1px);
 }
 
 /* Footer */
@@ -712,6 +888,102 @@ iframe {
     width: 100%;
 }
 
+/* Skeleton Screen */
+.skeleton-list {
+    padding: 0;
+}
+
+.skeleton-item {
+    padding: 18px 28px;
+    display: grid;
+    grid-template-columns: 44px 1fr auto;
+    gap: 14px;
+    align-items: center;
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.skeleton-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: var(--md-sys-color-outline-variant);
+}
+
+.skeleton-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.skeleton-line {
+    height: 12px;
+    border-radius: 6px;
+    background: var(--md-sys-color-outline-variant);
+}
+
+.skeleton-line.short {
+    width: 40%;
+}
+
+.skeleton-line.medium {
+    width: 70%;
+}
+
+.skeleton-line.long {
+    width: 90%;
+}
+
+.skeleton-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+}
+
+.skeleton-badge {
+    height: 10px;
+    width: 60px;
+    border-radius: 5px;
+    background: var(--md-sys-color-outline-variant);
+}
+
+.shimmer {
+    position: relative;
+    overflow: hidden;
+}
+
+.shimmer::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255,255,255,0.4) 50%,
+        transparent 100%
+    );
+    animation: shimmerMove 1.5s ease-in-out infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+    .shimmer::after {
+        background: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(255,255,255,0.08) 50%,
+            transparent 100%
+        );
+    }
+}
+
+@keyframes shimmerMove {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(100%); }
+}
+
 /* Loading */
 .loading {
     position: fixed;
@@ -738,8 +1010,8 @@ iframe {
     width: 48px;
     height: 48px;
     border: 4px solid rgba(255, 255, 255, 0.2);
-    border-top-color: #818CF8;
-    border-right-color: #A78BFA;
+    border-top-color: var(--theme-spinner-top);
+    border-right-color: var(--theme-spinner-right);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
 }
@@ -849,6 +1121,16 @@ iframe {
     to { opacity: 1; }
 }
 
+@keyframes floatEnvelope {
+    0%, 100% { transform: translate(-50%, -50%) translateY(0); }
+    50% { transform: translate(-50%, -50%) translateY(-8px); }
+}
+
+@keyframes twinkle {
+    0%, 100% { opacity: 0.3; transform: scale(1); }
+    50% { opacity: 0.7; transform: scale(1.3); }
+}
+
 /* Global Focus Ring */
 :focus-visible {
     outline: 2px solid var(--md-sys-color-primary);
@@ -928,5 +1210,179 @@ iframe {
     .app-title h1 {
         white-space: normal;
         overflow-wrap: break-word;
+    }
+
+    .skeleton-item {
+        grid-template-columns: 1fr auto;
+        padding: 14px 16px;
+    }
+
+    .skeleton-avatar {
+        display: none;
+    }
+}
+
+/* ===== Violet Theme ===== */
+html[data-theme="violet"] {
+    --md-sys-color-primary: #7C3AED;
+    --md-sys-color-primary-container: #EDE9FE;
+    --md-sys-color-on-primary-container: #4C1D95;
+    --md-sys-color-surface-variant: #F5F3FF;
+    --md-sys-color-background: #F8F7FC;
+    --md-sys-color-detail-bg: #FAFAFE;
+    --md-sys-color-card-border: #E8E5F0;
+    --gradient-primary: linear-gradient(135deg, #7C3AED, #A855F7);
+    --gradient-accent: linear-gradient(135deg, #7C3AED, #6366F1);
+    --gradient-subtle: linear-gradient(135deg, rgba(124,58,237,0.05), rgba(168,85,247,0.02));
+    --elevation-glow: 0 0 24px rgba(124,58,237,0.18);
+    --theme-appbar-shadow: rgba(124,58,237,0.3);
+    --theme-focus-ring: rgba(124,58,237,0.12);
+    --theme-btn-glow: rgba(124,58,237,0.4);
+    --theme-hover-bg: rgba(124,58,237,0.08);
+    --theme-avatar-shadow: 0 2px 8px rgba(124,58,237,0.2);
+    --theme-spinner-top: #A78BFA;
+    --theme-spinner-right: #C084FC;
+    --theme-tab-active-bg: var(--md-sys-color-primary);
+    --theme-tab-active-color: var(--md-sys-color-on-primary);
+    --theme-tab-active-shadow: 0 2px 8px rgba(124,58,237,0.25);
+}
+
+@media (prefers-color-scheme: dark) {
+    html[data-theme="violet"] {
+        --md-sys-color-primary: #A78BFA;
+        --md-sys-color-primary-container: #3B1F7E;
+        --md-sys-color-on-primary-container: #DDD6FE;
+        --gradient-primary: linear-gradient(135deg, #1E1B4B, #312E81);
+        --gradient-accent: linear-gradient(135deg, #4C1D95, #3730A3);
+        --gradient-subtle: linear-gradient(135deg, rgba(167,139,250,0.08), rgba(139,92,246,0.04));
+        --elevation-glow: 0 0 24px rgba(167,139,250,0.12);
+        --theme-appbar-shadow: rgba(167,139,250,0.2);
+        --theme-focus-ring: rgba(167,139,250,0.12);
+        --theme-btn-glow: rgba(167,139,250,0.3);
+        --theme-hover-bg: rgba(167,139,250,0.08);
+        --theme-avatar-shadow: 0 2px 8px rgba(167,139,250,0.15);
+        --theme-spinner-top: #A78BFA;
+        --theme-spinner-right: #C084FC;
+        --theme-tab-active-bg: var(--md-sys-color-primary);
+        --theme-tab-active-color: var(--md-sys-color-on-primary);
+        --theme-tab-active-shadow: 0 2px 8px rgba(167,139,250,0.2);
+    }
+}
+
+/* Violet Theme - Structural Overrides */
+html[data-theme="violet"] .app-bar::after {
+    content: '';
+    position: absolute;
+    bottom: -30%;
+    left: 10%;
+    width: 150px;
+    height: 150px;
+    background: radial-gradient(circle, rgba(255,255,255,0.06) 0%, transparent 70%);
+    pointer-events: none;
+}
+
+html[data-theme="violet"] .app-bar::before {
+    background: radial-gradient(circle, rgba(255,255,255,0.12) 0%, transparent 70%);
+}
+
+html[data-theme="violet"] .app-title h1 {
+    background: linear-gradient(135deg, #FFFFFF 0%, rgba(255,255,255,0.85) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+html[data-theme="violet"] .form-group input {
+    border-radius: 14px;
+    border-width: 1.5px;
+}
+
+html[data-theme="violet"] .btn-primary {
+    border-radius: 16px;
+    padding: 12px 28px;
+}
+
+html[data-theme="violet"] .btn-primary::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50%;
+    background: linear-gradient(180deg, rgba(255,255,255,0.15), transparent);
+    pointer-events: none;
+    border-radius: 16px 16px 0 0;
+}
+
+html[data-theme="violet"] .email-item {
+    position: relative;
+}
+
+html[data-theme="violet"] .email-item::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: var(--gradient-primary);
+    opacity: 0;
+    transition: opacity var(--transition-normal);
+    border-radius: 0 2px 2px 0;
+}
+
+html[data-theme="violet"] .email-item:hover::before {
+    opacity: 0.5;
+}
+
+html[data-theme="violet"] .email-item.active::before {
+    opacity: 1;
+    background: var(--gradient-accent);
+}
+
+html[data-theme="violet"] .email-summary {
+    padding-left: 32px;
+}
+
+html[data-theme="violet"] .avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    font-size: 16px;
+}
+
+html[data-theme="violet"] .chip {
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+html[data-theme="violet"] .info-card {
+    border-radius: 14px;
+}
+
+html[data-theme="violet"] .tabs {
+    border-radius: 24px;
+}
+
+html[data-theme="violet"] .tab-btn {
+    border-radius: 20px;
+}
+
+html[data-theme="violet"] .iframe-wrapper {
+    border-radius: 14px;
+}
+
+html[data-theme="violet"] .text-content {
+    border-radius: 14px;
+}
+
+html[data-theme="violet"] .attachment-item {
+    border-radius: 12px;
+}
+
+@media (max-width: 600px) {
+    html[data-theme="violet"] .email-summary {
+        padding-left: 20px;
     }
 }


### PR DESCRIPTION
## Summary
- 将主题切换从单按钮 toggle 改为下拉选择菜单，支持 Indigo/Violet 两个主题
- 下拉选项带有色块预览和当前选中勾号标记
- 支持点击外部自动关闭下拉菜单
- 修复 app-bar `overflow: hidden` 导致下拉菜单被裁剪的问题

## Test plan
- [x] 点击调色板按钮，下拉弹出显示 Indigo (✓) 和 Violet 两个选项
- [x] 选择 Violet，主题立即切换，下拉关闭，再打开显示 Violet (✓)
- [x] 点击下拉外部区域，下拉正确关闭
- [x] 刷新页面后主题保持，下拉打开后正确标记当前主题
- [x] 移动端下拉不溢出屏幕（right: 0 对齐）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme support with selectable light/dark themes that persist across sessions
  * Introduced skeleton loading screens for improved loading experience
  * Enhanced empty state messaging with contextual hints for better guidance

* **Improvements**
  * Refined email list animations for smoother visual rendering
  * Updated UI styling to support theme-aware visuals and color adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->